### PR TITLE
fix: Initialize DirectX library

### DIFF
--- a/src/com/jagex/Class306.java
+++ b/src/com/jagex/Class306.java
@@ -1,24 +1,26 @@
 package com.jagex;
-import java.lang.reflect.Method;
+import java.awt.Canvas;
 
 public class Class306
 {
-	static final GraphicsToolkit method3566(Class302 class302, int i, int i_0_, d var_d, java.awt.Canvas canvas) {
+	static GraphicsToolkit initD3D(Class302 class302, int i, d var_d, Canvas canvas) {
 		GraphicsToolkit graphicstoolkit;
+
 		try {
 			if (!Class352.method4012(71)) {
 				throw new RuntimeException("");
 			}
+
 			if (!Node_Sub38_Sub2.method2793(1, "jagdx")) {
 				throw new RuntimeException("");
 			}
-			Class var_class = Class.forName("kea");
-			int i_1_ = -80 % ((-68 - i_0_) / 51);
-			Method method = var_class.getDeclaredMethod("createToolkit", new Class[] { Class.forName("java.awt.Canvas"), Class.forName("com.jagex.d"), Class.forName("com.jagex.Class302"), Class.forName("java.lang.Integer") });
-			graphicstoolkit = (GraphicsToolkit) method.invoke(null, new Object[] { canvas, var_d, class302, new Integer(i) });
+
+			graphicstoolkit = D3DToolkit.createToolkit(canvas, var_d, class302, i);
 		} catch (Throwable throwable) {
+			throwable.printStackTrace();
 			throw new RuntimeException("");
 		}
+
 		return graphicstoolkit;
 	}
 }

--- a/src/com/jagex/GraphicsToolkit.java
+++ b/src/com/jagex/GraphicsToolkit.java
@@ -212,7 +212,7 @@ abstract class GraphicsToolkit
 			return Node_Sub20.method2613(i_113_, 1, class302, var_d, canvas);
 		}
 		if ((i_114_ ^ 0xffffffff) == -4) {
-			return Class306.method3566(class302, i_113_, 89, var_d, canvas);
+			return Class306.initD3D(class302, i_113_, var_d, canvas);
 		}
 		throw new IllegalArgumentException("UM");
 	}


### PR DESCRIPTION
The specific issue here was "kea" (obfuscated name) not being renamed to D3DToolkit.

I replaced the reflection with real access, it's no longer necessary as every class is always available. Also left a printStackTrace() call in for user troubleshooting.