### PR TITLE
Fixed Java 17 compile errors

### DIFF
--- a/src/com/jagex/Class2.java
+++ b/src/com/jagex/Class2.java
@@ -9,18 +9,20 @@ public class Class2
 		if (b != -37) {
 			return null;
 		}
-		return JSObject.getWindow(applet).call(string, objects);
+		//return JSObject.getWindow(applet).call(string, objects);
+		return null;
 	}
 	
 	static final Object method167(String string, Applet applet, byte b) throws Throwable {
 		if (b > -62) {
 			return null;
 		}
-		return JSObject.getWindow(applet).call(string, null);
+		//return JSObject.getWindow(applet).call(string, null);
+		return null;
 	}
 	
 	static final void method168(String string, Applet applet, int i) throws Throwable {
-		JSObject.getWindow(applet).eval(string);
+		//JSObject.getWindow(applet).eval(string);
 		if (i == 30639) {
 			/* empty */
 		}


### PR DESCRIPTION
Java 11 seems to have removed JSObject, and these methods seem unused, so we can safely return null.